### PR TITLE
Change vis type name back to jVectorMapCountry

### DIFF
--- a/public/jvector_map_country_vis.js
+++ b/public/jvector_map_country_vis.js
@@ -17,7 +17,7 @@ function jvectormapcountryProvider(Private) {
 
 	// Describe our visualization
 	return new TemplateVisType({
-		name: 'jvectormapcountry', // The internal id of the visualization (must be unique)
+		name: 'jVectorMapCountry', // The internal id of the visualization (must be unique)
 		title: 'Offline Country Map', // The title of the visualization, shown to the user
 		description: 'Offline Country Map Visualizer using jVectormap.', // The description of this vis
 		icon: 'fa-map', // The font awesome icon of this visualization


### PR DESCRIPTION
Closes #2

The name of the vis type was changed to `jvectormapcountry` in c3e25ee, which breaks any previously created visualizations, particularly from snuids/jVectorMapKibanaCountry. This PR undoes that name change.